### PR TITLE
Fix if-condition in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ env:
 jobs:
   if_release:
     if: |
-        ${{ github.event.pull_request.merged == true }}
-        && ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
+        github.event.pull_request.merged == true
+        && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Closes #19

This fixes #19 by [omitting each opening and closing `${{` `}}`](https://docs.github.com/en/actions/learn-github-actions/expressions#about-expressions) from the `if`-condition, preventing the unintended conversion to truthy strings. I've tested that this fixes the bug, by examining the behavior in some PRs internal to my fork:

- As noted in #19, I noticed the issue in EliahKagan#1 ([view run](https://github.com/EliahKagan/wasm_exec/actions/runs/5994981651)).

- In EliahKagan#4, I tested that the fix prevents a release from being attempted due to the closure of a PR that does not have the `release` label applied to it, whether the PR is [closed without merging](https://github.com/EliahKagan/wasm_exec/pull/4#issuecomment-1695097979) ([view run](https://github.com/EliahKagan/wasm_exec/actions/runs/5996377704)), or [closed by being merged](https://github.com/EliahKagan/wasm_exec/pull/4#issuecomment-1695113527) ([view run](https://github.com/EliahKagan/wasm_exec/actions/runs/5996469578)).

- In EliahKagan#5, I tested that the fix prevents a release from being attempted due to the closure of a PR that does have the `release` label but that is [closed without merging](https://github.com/EliahKagan/wasm_exec/pull/5#issuecomment-1695138358) ([view run](https://github.com/EliahKagan/wasm_exec/actions/runs/5996641363)), and that the fix still allows a release to be attempted when a PR that does have the `release` label is [closed by being merged](https://github.com/EliahKagan/wasm_exec/pull/5#issuecomment-1695151356) ([view run](https://github.com/EliahKagan/wasm_exec/actions/runs/5996708839); this failed because my fork is not set up to publish, but this verifies the correct logic).

[All release workflow runs in my fork can be seen here.](https://github.com/EliahKagan/wasm_exec/actions/workflows/release.yml)

If this PR is merged, I think it still won't automatically take effect for #18, since the `pull_request` trigger uses the configuration in the head (feature) branch rather than the base (target) branch. However, due to a combination of the reasons given in #19, I don't think unwanted publishing attempted due to #18 would succeed in the case of #18. Furthermore, if this is merged, #18 could be rebased onto main, or main merged into it, in which case the fix would definitely apply when subsequently rejecting or accepting #18.