### PR TITLE
Run CI tests on 3.12 and multiple operating systems

### DIFF
--- a/.github/actions/poetry_setup/action.yml
+++ b/.github/actions/poetry_setup/action.yml
@@ -11,6 +11,11 @@ inputs:
     description: Python version, supporting MAJOR.MINOR only
     required: true
 
+  python-allow-prereleases:
+    description: Whether to setup-python may install a prerelease of Python
+    required: false
+    default: false
+
   poetry-version:
     description: Poetry version
     required: true
@@ -36,6 +41,7 @@ runs:
       name: Setup python $${ inputs.python-version }}
       with:
         python-version: ${{ inputs.python-version }}
+        allow-prereleases: ${{ inputs.python-allow-prereleases }}
 
     - uses: actions/cache@v3
       id: cache-pip

--- a/.github/actions/poetry_setup/action.yml
+++ b/.github/actions/poetry_setup/action.yml
@@ -53,8 +53,20 @@ runs:
           ~/.cache/pip
         key: pip-${{ runner.os }}-${{ runner.arch }}-py-${{ inputs.python-version }}
 
-    - run: pipx install poetry==${{ inputs.poetry-version }} --python python${{ inputs.python-version }}
+    - name: Update PyPI packages
       shell: bash
+      run: |
+        python -m pip install -U pip wheel
+
+        # Python prior to 3.12 ships setuptools. Upgrade it if present.
+        if pip freeze --all | grep -q '^setuptools=='; then
+            python -m pip install -U setuptools
+        fi
+
+    - name: Install Poetry
+      shell: bash
+      run: |
+        pip install poetry==${{ inputs.poetry-version }}
 
     - name: Check Poetry File
       shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,6 @@
 name: lint
 
-on:
-  push:
-    branches: [main]
-  pull_request:
+on: [push, pull_request, workflow_dispatch]
 
 env:
   POETRY_VERSION: "1.4.2"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: lint
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  POETRY_VERSION: "1.4.2"
+  POETRY_VERSION: "1.6.1"
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install poetry
         run: |
-          pipx install poetry==$POETRY_VERSION
+          pipx install poetry=="$POETRY_VERSION"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: lint
+name: Lint
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -6,7 +6,7 @@ env:
   POETRY_VERSION: "1.6.1"
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: Release
 
 on:
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry
-        run: pipx install poetry==$POETRY_VERSION
+        run: pipx install poetry=="$POETRY_VERSION"
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
@@ -32,7 +32,7 @@ jobs:
       - name: Check Version
         id: check-version
         run: |
-          echo version=$(poetry version --short) >> $GITHUB_OUTPUT
+          echo "version=$(poetry version --short)" >> "$GITHUB_OUTPUT"
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
       - 'pyproject.toml'
 
 env:
-  POETRY_VERSION: "1.4.2"
+  POETRY_VERSION: "1.6.1"
 
 jobs:
   if_release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: test
 
 on: [push, pull_request, workflow_dispatch]
 
-env:
-  POETRY_VERSION: "1.4.2"
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,12 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os:
+          - ubuntu
+          - macos
+          - windows
         python-version:
           - "3.8"
           - "3.9"
@@ -14,12 +17,13 @@ jobs:
           - "3.11"
           - "3.12"
         test_type:
-          - "core"
+          - core
         include:
           - experimental: false
           - python-version: "3.12"
             experimental: true
     continue-on-error: ${{ matrix.experimental }}
+    runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: test
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 env:
   POETRY_VERSION: "1.4.2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
-name: test
+name: Test
 
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,7 +20,6 @@ jobs:
           - python-version: "3.12"
             experimental: true
     continue-on-error: ${{ matrix.experimental }}
-    name: Python ${{ matrix.python-version }} ${{ matrix.test_type }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: "./.github/actions/poetry_setup"
         with:
           python-version: ${{ matrix.python-version }}
-          poetry-version: "1.4.2"
+          poetry-version: "1.6.1"
           cache-key: ${{ matrix.test_type }}
           install-command: |
               if [ "${{ matrix.test_type }}" == "core" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,14 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         test_type:
           - "core"
+        include:
+          - experimental: false
+          - python-version: "3.12"
+            experimental: true
+    continue-on-error: ${{ matrix.experimental }}
     name: Python ${{ matrix.python-version }} ${{ matrix.test_type }}
     steps:
       - uses: actions/checkout@v3
@@ -21,6 +27,7 @@ jobs:
         uses: "./.github/actions/poetry_setup"
         with:
           python-version: ${{ matrix.python-version }}
+          python-allow-prereleases: ${{ matrix.experimental }}
           poetry-version: "1.6.1"
           cache-key: ${{ matrix.test_type }}
           install-command: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-        test_type:
+        test-type:
           - core
         include:
           - experimental: false
@@ -32,18 +32,18 @@ jobs:
           python-version: ${{ matrix.python-version }}
           python-allow-prereleases: ${{ matrix.experimental }}
           poetry-version: "1.6.1"
-          cache-key: ${{ matrix.test_type }}
+          cache-key: ${{ matrix.test-type }}
           install-command: |
-              if [ "${{ matrix.test_type }}" == "core" ]; then
+              if [ "${{ matrix.test-type }}" == "core" ]; then
                 echo "Running core tests, installing dependencies with poetry..."
                 poetry install --only=main,test
               else
                 echo "Running extended tests, installing dependencies with poetry..."
                 poetry install --only=main,test --all-extras
               fi
-      - name: Run ${{matrix.test_type}} tests
+      - name: Run ${{matrix.test-type}} tests
         run: |
-          if [ "${{ matrix.test_type }}" == "core" ]; then
+          if [ "${{ matrix.test-type }}" == "core" ]; then
             make test
           else
             make extended_tests


### PR DESCRIPTION
This expands the CI matrix in `test.yml` by:

- **Testing Python 3.12** in addition to 3.8, 3.9, 3.10, and 3.11. Currently Python 3.12 is in release candidate 2. Testing with it before the stable 3.12.0 release comes out [is encouraged](https://discuss.python.org/t/python-3-12-0-release-candidate-1-released/31137#call-to-action-2).
- **Testing macOS and Windows** as well as Ubuntu. I would advocate this as a general practice, but there is also a specific reason that applies for wasm_exec, in that wasmtime includes platform-specific code. Since wasmtime's documentation recommends it be updated monthly, I think it's useful to be able to automate this as much as possible. Doing more testing, as introduced here, would give greater confidence when adding such automation later. (For example, wasmtime updates could be taken using Dependabot, by issuing `@dependabot merge` on a Dependabot PR, to cause the update to be merged only if, and after, all checks have passed, including running all tests on all supported version of Python on three operating systems.)

A few important things this PR does *not* do:

- **This is completely independent of what Python version the Python WASM runtime uses.** Currently this remains, as you have noted in the readme, 3.11-only. (From [this section of the Wasm Labs page](https://wasmlabs.dev/articles/python-wasm32-wasi/#about-the-build-and-artifacts), it seems VMWare may release a 3.12 runtime at some point after a stable 3.12 release comes out. This PR does not cover that at all.)
- **I did not expand the matrix in the linting workflow.** I'm not sure it's necessary to lint on multiple versions at all, much less operating systems. Either way, though, I think linting is far less likely to break in a new version, and also that the effect of breaking linting is much less severe in terms of what bugs in reveals. If continuing to lint on multiple versions, then 3.12 should be added once the stable 3.12.0 is released.
- **I did not do anything related to updating Python or GitHub Actions dependencies.** Although I think part of the benefit of expanding the test matrix is to provide greater confidence in doing regular updates with Dependabot, or Renovatebot, etc., it seems to me that this PR would be too broadly scoped if it tried to do anything with that. The considerations when reviewing those kinds of changes would, I think, be largely different from the ones here. Furthermore, I think the benefit of more automated testing can stand by itself.

Although I think it remains to be seen if the complexity of caching for `poetry` across CI runs is worthwhile for this repository, I suspect it very well may be worthwhile, since it's possible that, in the future, extended testing may include testing the effect of changes on specific applications or libraries like langchain, some of which are themselves sizable once their dependencies are accounted for. Therefore, I have kept, and tried to make sure not to break, the caching logic. Caching doesn't seem to be working on my feature branch for the newly introdued operating systems, but based on [Actions/cache: Cache not being hit despite of being present](https://github.com/orgs/community/discussions/27059#discussioncomment-3254477) I think that is normal and hope it will simply work once those new caches are created on main (if you choose to merge this PR). However, separately from that, I have had to make a couple of changes to `actions/poetry_setup/action.yml`:

- **Added a `python-allow-prereleases` option** to allow a value to be passed through to the `setup-python` action's `allow-prereleases` key. Either this or hard-coding `true` is needed to install a prerelease. I think adding an option is better. Furthermore, while the logic that special-cases 3.12 should, it seems to me, be removed from `test.yml` soon after 3.12.0 comes out, the `python-allow-prereleases` option added to `poetry_setup` could be reused in the future (if `poetry_setup` is still in use at that time).
- **Installed `poetry` with `pip` instead of `pipx`**, because `pipx` (and, as a result, `poetry`) do not find the correct interpreter on macOS and Windows GitHub Actions runners without significant effort. This is undesirable, but I believe the alternatives are worse. Commands that pass the Python version to `pipx`, as that workflow was doing, tend not to work very well on the macOS and Windows runners. The exact path to the Python executable is not made directly available by `setup-python`, and while the installation directory is available, the relative path to the interpreter varies by operating system. If other Python implementations such as PyPy are tested in the future, the situation becomes even worse in that regard. Furthermore, because the Windows runner has Python and `pipx`, what seems like it works will often instead just everything with the system Python instead of the one `setup-python` installed. Using `pip` eliminates all these problems with no added complexity for selecting the correct version, because `setup-python` provides `pip` on all platforms.

I have also made some other changes that seem to me to be useful in light of all the above changes:

- **Tweak the style of test names**, so they are less likely to be cut off in the GitHub Actions web-based interface. This counterbalances the lengthening effect of operating system names being included in the job names. The job names are now fully automatically generated, rather than through interpolating `${{ }}` expressions. I changed the names of the job keys, e.g. `build` to `test` in `test.yml`, so that the generated names would be good. I changed the values associated with the workflow `name` keys to be capitalized, so they would be styled differently from job names.
- **Specify a newer version of `poetry`**, [1.6.1](https://python-poetry.org/history/#161---2023-08-21), which is currently the latest. I was unsure if I should do that in this PR or separately, but I decided to do it here because, as of [1.6.0](https://python-poetry.org/history/#160---2023-08-20), there are performance improvements that I think are worth having when expanding CI. (The runners run in parallel, for the most part, but the macOS and Windows runners tend to run Python code slower, including for `pip` and `poetry`.)
- **Small cleanup.** For example, the test workflow, unlike the others, specifies the Poetry version with the `poetry-version` key passed to `actions/poetry_setup/action.yml`, but it also had a `POETRY_VERSION` environment variable defined at the top that had no effect, but appeared to control the version.
- **Run test and lint jobs on all branches**, rather than just `main` and branches that have an open pull request targeting `main`. Although this has the disadvantage that it will double up CI checks on PRs that originate in this upstream repository (i.e., that you open yourself), I think that is outweighed by the advantage that, for anyone who has enabled GitHub Actions in their fork, CI checks will run even without, or before, a pull request is opened. This makes trying out changes one is not sure will work out and justify a PR easier. This was the first thing I did (it is in the first commit here) and I found it very valuable because I was able to test various approaches before even opening this pull request, and to do so without requiring any added steps.

However, some of that is subjective! I would be pleased to make any requested changes to this PR (and/or please feel free to push commits).